### PR TITLE
feat: integrate Dromajo co-simulation (per-instruction difftest)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/dromajo"]
+	path = tools/dromajo
+	url = https://github.com/texerai/dromajo.git

--- a/rtl/write_back_stage.sv
+++ b/rtl/write_back_stage.sv
@@ -76,6 +76,11 @@ module write_back_stage
         longint unsigned mem_val,
         longint unsigned mem_addr,
         byte unsigned mem_we);
+    import "DPI-C" function void dromajo_step(
+        longint unsigned pc,            // uint64_t
+        int unsigned insn,              // uint32_t
+        longint unsigned wdata,         // uint64_t
+        byte unsigned reg_we);          // uint8_t
 
     always_comb begin
         if (ecall_instr_i) begin
@@ -92,10 +97,11 @@ module write_back_stage
     assign rd_addr_o = rd_addr_i;
     assign reg_we_o  = reg_we_i;
 
-    // Log trace.
+    // Log trace and co-simulation step.
     always_comb begin
         if (log_trace_i) begin
-            log_trace (pc_log_i, instruction_log_i, result_o, rd_addr_i, reg_we_i, mem_access_log_i, mem_write_data_log_i, mem_addr_log_i, mem_we_log_i);
+            log_trace   (pc_log_i, instruction_log_i, result_o, rd_addr_i, reg_we_i, mem_access_log_i, mem_write_data_log_i, mem_addr_log_i, mem_we_log_i);
+            dromajo_step(pc_log_i, instruction_log_i, result_o, reg_we_i);
         end
     end
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -39,7 +39,7 @@ PERF_RESULT_FILE = ROOT / "results/perf_result.txt"
 TEST_ENV_FILE = ROOT / "rtl/test_env.sv"
 DCACHE_FILE = ROOT / "rtl/dcache.sv"
 
-DROMAJO_DIR     = Path("/home/yesmurat06/projects/dromajo")
+DROMAJO_DIR     = ROOT / "tools/dromajo"
 DROMAJO_INCLUDE = DROMAJO_DIR / "include"
 DROMAJO_LIB     = DROMAJO_DIR / "build" / "libdromajo_cosim.a"
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -39,6 +39,10 @@ PERF_RESULT_FILE = ROOT / "results/perf_result.txt"
 TEST_ENV_FILE = ROOT / "rtl/test_env.sv"
 DCACHE_FILE = ROOT / "rtl/dcache.sv"
 
+DROMAJO_DIR     = Path("/home/yesmurat06/projects/dromajo")
+DROMAJO_INCLUDE = DROMAJO_DIR / "include"
+DROMAJO_LIB     = DROMAJO_DIR / "build" / "libdromajo_cosim.a"
+
 OBJ_DIR = ROOT / "obj_dir"
 SIM_BINARY = OBJ_DIR / "Vtest_env"
 RES_FILE = ROOT / "res.txt"
@@ -90,6 +94,7 @@ HELP_MSG_COVERAGE_ALL_DESCRIPTION = "Generate both line and toggle coverage."
 HELP_MSG_COVERAGE_LINE_DESCRIPTION = "Generate line coverage only."
 HELP_MSG_COVERAGE_TOGGLE_DESCRIPTION = "Generate toggle coverage only."
 HELP_MSG_PREP_FOR_COMMIT_DESCRIPTION = "Remove generated artifacts and restore autoupdated tracked files."
+HELP_MSG_COSIM_ONLY_DESCRIPTION = "Run only the Dromajo co-simulation; skip Spike trace generation and tracecomp."
 
 
 class RunTestsError(Exception):
@@ -403,6 +408,7 @@ class TestRunner:
         self.args = args
         self.command_runner = CommandRunner(ROOT)
         self.coverage_mode = self._resolve_coverage_mode()
+        self.cosim_only = args.cosim_only
         self.default_block_width = self._read_parameter_value(TEST_ENV_FILE, "BLOCK_WIDTH")
         self.default_set_count = self._read_parameter_value(DCACHE_FILE, "SET_COUNT")
         self.default_associativity = self._read_parameter_value(DCACHE_FILE, "N")
@@ -540,9 +546,10 @@ class TestRunner:
             f"(BLOCK_WIDTH={block_width}, SET_COUNT={set_count}, ASSOCIATIVITY={associativity}-way)"
         )
 
+        elf_path = self._memory_path_to_elf_path(memory_path)
         self._configure_test_files(test_name, memory_path, block_width, set_count, associativity)
         self._build_simulator(gen_wave=self.args.trace, coverage_mode=self.coverage_mode)
-        self._run_simulation(test_name)
+        self._run_simulation(test_name, elf_path)
 
         parsed_output = self._parse_simulation_output(test_name)
         self._write_rtl_trace(test_name, parsed_output.trace_lines)
@@ -555,8 +562,11 @@ class TestRunner:
             self._record_test_outcome(test_name, outcome)
             raise TestFailure(f"Self Check failed for {test_name}: {self_check}. See {format_repo_path(RES_FILE)}.")
 
-        self._run_trace_reference(test_name, memory_path)
-        tracecomp_status, trace_preview = self._compare_traces(test_name)
+        if self.cosim_only:
+            tracecomp_status = "Skipped"
+        else:
+            self._run_trace_reference(test_name, memory_path)
+            tracecomp_status, trace_preview = self._compare_traces(test_name)
 
         outcome = TestOutcome(self_check=self_check, tracecomp=tracecomp_status, perf_summary=perf_summary)
         self._record_test_outcome(test_name, outcome)
@@ -645,10 +655,13 @@ class TestRunner:
             verilator_command.append("--trace")
         verilator_command.extend(
             [
+                "-CFLAGS", f"-I{DROMAJO_INCLUDE}",
                 "--exe",
                 format_repo_path(ROOT / "test/tb/tb_test_env.cpp"),
                 format_repo_path(ROOT / "test/tb/check.c"),
                 format_repo_path(ROOT / "test/tb/log_trace.c"),
+                format_repo_path(ROOT / "test/tb/dromajo_cosim.cpp"),
+                str(DROMAJO_LIB),
             ]
         )
 
@@ -658,10 +671,10 @@ class TestRunner:
             description="Build generated simulator",
         )
 
-    def _run_simulation(self, test_name: str) -> None:
+    def _run_simulation(self, test_name: str, elf_path: Path) -> None:
         self._remove_path(RES_FILE)
         self.command_runner.run_streaming_to_file(
-            [format_repo_path(SIM_BINARY)],
+            [format_repo_path(SIM_BINARY), format_repo_path(elf_path)],
             description=f"Run RTL simulation for {test_name}",
             output_path=RES_FILE,
             timeout=SIMULATION_TIMEOUT_SECONDS,
@@ -1043,6 +1056,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
     parser.add_argument("-v", "--compile-varying-cache", action="store_true", help=HELP_MSG_VARYING_DESCRIPTION)
     parser.add_argument("-t", "--trace", action="store_true", help=HELP_MSG_TRACE_DESCRIPTION)
+    parser.add_argument("--cosim-only", action="store_true", help=HELP_MSG_COSIM_ONLY_DESCRIPTION)
 
     coverage_group = parser.add_mutually_exclusive_group()
     coverage_group.add_argument("-ca", "--coverage-all", action="store_true", help=HELP_MSG_COVERAGE_ALL_DESCRIPTION)
@@ -1065,6 +1079,8 @@ def validate_arguments(args: argparse.Namespace) -> None:
         raise ConfigurationError("--compile-varying-cache (-v) must be used with -s, -g, or -a.")
     if args.trace and not is_test_run:
         raise ConfigurationError("--trace can only be used with a test-running command.")
+    if args.cosim_only and not is_test_run:
+        raise ConfigurationError("--cosim-only can only be used with a test-running command.")
     if coverage_requested and not is_test_run:
         raise ConfigurationError("Coverage options can only be used with a test-running command.")
 

--- a/test/tb/dromajo_cosim.cpp
+++ b/test/tb/dromajo_cosim.cpp
@@ -1,0 +1,138 @@
+/* Copyright (c) 2024 Maveric NU. All rights reserved. */
+
+// ---------------------------------------------------------------------------
+// Dromajo co-simulation interface for Maveric Core 2.0.
+//
+// This file provides three functions:
+//
+//   dromajo_init(elf_path)   -- called from tb_test_env.cpp before the clock
+//                               starts; initialises the Dromajo golden model
+//                               with the same ELF the DUT is running.
+//
+//   dromajo_step(...)        -- DPI-C function imported by write_back_stage.sv
+//                               and called once per retired instruction; steps
+//                               the golden model one instruction and compares
+//                               its result against the DUT values.
+//
+//   dromajo_fini()           -- called from tb_test_env.cpp after simulation
+//                               ends; releases Dromajo resources.
+//
+//   dromajo_has_error()      -- returns 1 if any mismatch has been detected.
+// ---------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdint.h>
+
+#include "dromajo_cosim.h"
+
+static dromajo_cosim_state_t *cosim_state = nullptr;
+static bool                   cosim_error = false;
+static bool                   cosim_done  = false;  // Dromajo signalled clean termination (HTIF exit 0)
+
+
+// ---------------------------------------------------------------------------
+// dromajo_init -- initialise the golden model.
+//
+// Dromajo's init function takes an argv-style array, just like main().
+// --reset_vector 0x80000000 tells Dromajo to start executing from the ELF
+// entry point directly, matching the DUT which has no boot ROM.
+// ---------------------------------------------------------------------------
+extern "C" void dromajo_init(const char *elf_path) {
+    char  progname[]      = "dromajo";
+    char  reset_flag[]    = "--reset_vector";
+    char  reset_addr[]    = "0x80000000";
+
+    char *argv[] = {
+        progname,
+        reset_flag,
+        reset_addr,
+        const_cast<char *>(elf_path),
+        nullptr
+    };
+    int argc = 4;
+
+    cosim_state = dromajo_cosim_init(argc, argv);
+    if (!cosim_state) {
+        fprintf(stderr, "[cosim] ERROR: dromajo_cosim_init failed for %s\n", elf_path);
+        exit(EXIT_FAILURE);
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// dromajo_fini -- release Dromajo resources.
+// ---------------------------------------------------------------------------
+extern "C" void dromajo_fini() {
+    if (cosim_state) {
+        dromajo_cosim_fini(cosim_state);
+        cosim_state = nullptr;
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// dromajo_step -- DPI-C: called by write_back_stage.sv at every retirement.
+//
+// Parameters mirror what the RTL already passes to log_trace:
+//   pc     : program counter of the retiring instruction
+//   insn   : 32-bit instruction word
+//   wdata  : value written to the destination register (0 if no reg write)
+//   reg_we : 1 if the instruction writes an integer register, else 0
+//
+// ECALL (0x00000073) is skipped: the DUT suppresses it in log_trace and
+// the check() DPI call handles program termination separately.
+// ---------------------------------------------------------------------------
+extern "C" void dromajo_step(
+    uint64_t pc,
+    uint32_t insn,
+    uint64_t wdata,
+    uint8_t  reg_we)
+{
+    if (!cosim_state || cosim_error || cosim_done) return;
+
+    // Skip ECALL/EBREAK — both are handled by check() + $finish in the DUT.
+    // Passing either to dromajo_cosim_step causes an infinite exception loop
+    // inside Dromajo (no M-mode trap handler configured).
+    if (insn == 0x00000073 || insn == 0x00100073) return;
+
+    // When the instruction does not write a register, pass 0 so Dromajo
+    // does not attempt to match a stale wdata value.
+    uint64_t check_wdata = reg_we ? wdata : 0;
+
+    int ret = dromajo_cosim_step(
+        cosim_state,
+        0,            // hartid: single-core design
+        pc,
+        insn,
+        check_wdata,
+        0,            // mstatus: no CSR support yet, pass 0
+        true          // check: enable comparison
+    );
+
+    if (ret != 0) {
+        if (ret == 0x1FFF) {
+            // PC / insn / wdata comparison failed.
+            fprintf(stderr, "[cosim] MISMATCH at PC=0x%016lx  insn=0x%08x\n",
+                    (unsigned long)pc, insn);
+            cosim_error = true;
+        } else {
+            // ret == 1: Dromajo signalled clean termination (HTIF tohost written).
+            // The DUT will now spin waiting to be killed; exit immediately so the
+            // simulation does not run to MAX_SIM_TIME.
+            dromajo_cosim_fini(cosim_state);
+            cosim_state = nullptr;
+            cosim_done  = true;
+            exit(EXIT_SUCCESS);
+        }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// dromajo_has_error -- returns 1 if any mismatch was detected.
+// ---------------------------------------------------------------------------
+extern "C" int dromajo_has_error() {
+    return cosim_error ? 1 : 0;
+}

--- a/test/tb/tb_test_env.cpp
+++ b/test/tb/tb_test_env.cpp
@@ -11,6 +11,11 @@
 vluint64_t sim_time = 0;
 vluint64_t posedge_cnt = 0;
 
+// Dromajo co-simulation interface (defined in dromajo_cosim.cpp).
+extern "C" void dromajo_init(const char *elf_path);
+extern "C" void dromajo_fini();
+extern "C" int  dromajo_has_error();
+
 
 void dut_reset (Vtest_env *dut, vluint64_t &sim_time){
 
@@ -22,8 +27,18 @@ void dut_reset (Vtest_env *dut, vluint64_t &sim_time){
     }
 }
 
+// ELF path is passed as the first command-line argument after Verilator args.
+// Usage: Vtest_env <elf_path>
 int main(int argc, char** argv, char** env) {
     Verilated::commandArgs(argc, argv);
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <elf_path>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    const char *elf_path = argv[1];
+    dromajo_init(elf_path);
+
     Vtest_env *dut = new Vtest_env;
 //  Verilated::traceEverOn(true);
 //  VerilatedVcdC* sim_trace = new VerilatedVcdC;
@@ -45,7 +60,11 @@ int main(int argc, char** argv, char** env) {
 //  sim_trace->close();
 //  delete sim_trace;
 //  VerilatedCov::write("coverage.dat");
+
+    int cosim_failed = dromajo_has_error();
+    dromajo_fini();
+
     delete dut;
-    exit(EXIT_SUCCESS);
+    exit(cosim_failed ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
Added Dromajo co-simulation alongside the existing Spike tracecomp flow:

1. Created `dromajo_cosim.cpp` with `init`, `step`, `fini`, `has_error` functions.
2. Wired `dromajo_step` as a DPI-C import in `write_back_stage.sv`
3. Threads the ELF path through `run_tests.py` to the simulator binary and adds a `--cosim-only` flag to skip Spike trace generation.